### PR TITLE
support templated links without using @BeanParams

### DIFF
--- a/src/main/java/com/mercateo/common/rest/schemagen/link/LinkCreator.java
+++ b/src/main/java/com/mercateo/common/rest/schemagen/link/LinkCreator.java
@@ -136,7 +136,12 @@ public class LinkCreator {
         visitAnnotations((parameter, parameterIndex, annotation) -> {
             if (annotation instanceof PathParam) {
                 PathParam pathParamAnnotation = (PathParam) annotation;
-                pathParameters.put(pathParamAnnotation.value(), parameter);
+                String paramName = pathParamAnnotation.value();
+                if(parameter != null) {
+                	pathParameters.put(paramName, parameter);
+                } else {
+                	pathParameters.put(paramName, "{" + paramName + "}");
+                }
             } else if (annotation instanceof BeanParam) {
                 BeanParamExtractor beanParamExtractor = new BeanParamExtractor();
                 pathParameters.putAll(beanParamExtractor.getPathParameters(parameter));

--- a/src/test/java/com/mercateo/common/rest/schemagen/link/LinkCreatorTest.java
+++ b/src/test/java/com/mercateo/common/rest/schemagen/link/LinkCreatorTest.java
@@ -10,7 +10,9 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.Optional;
 
+import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Link;
 
@@ -93,6 +95,50 @@ public class LinkCreatorTest {
 
         assertEquals("http://localhost:8080/test/path?qp2=v2&qp1=v1", link.getUri().toString());
         assertEquals("GET", link.getParams().get("method"));
+    }
+    
+    @Test
+    public void testPathParam() throws NoSuchMethodException, SecurityException {
+		@Path("test")
+		class ImplementedGenricResource {
+			@GET
+			@Path("{pathParam1}")
+			@Produces("application/json")
+			public String get(@PathParam("pathParam1") String param) {
+				return "input:" + param;
+			}
+		}
+    	
+    	Scope scope = new CallScope(ImplementedGenricResource.class, ImplementedGenricResource.class.getMethod("get",
+    			String.class), new String[] { "foo" }, null);
+    	
+    	Link link = createFor(scope, Relation.of(Rel.SELF), URI.create(
+    			"http://localhost:8080/"));
+    	
+    	assertEquals("http://localhost:8080/test/foo", link.getUri().toString());
+    	assertEquals("GET", link.getParams().get("method"));
+    }
+    
+    @Test
+    public void testTemplatedPathParam() throws NoSuchMethodException, SecurityException {
+    	@Path("test")
+    	class ImplementedGenricResource {
+    		@GET
+    		@Path("{pathParam1}")
+    		@Produces("application/json")
+    		public String get(@PathParam("pathParam1") String param) {
+    			return "input:" + param;
+    		}
+    	}
+    	
+    	Scope scope = new CallScope(ImplementedGenricResource.class, ImplementedGenricResource.class.getMethod("get",
+    			String.class), new String[] { null }, null);
+    	
+    	Link link = createFor(scope, Relation.of(Rel.SELF), URI.create(
+    			"http://localhost:8080/"));
+    	
+    	assertEquals("http://localhost:8080/test/%7BpathParam1%7D", link.getUri().toString());
+    	assertEquals("GET", link.getParams().get("method"));
     }
 
     @Test


### PR DESCRIPTION
Links with template-params in the path of the uri where only supported, if the pathparam was part of a beanparam-object. With this change it's also supported for @PathParam-annotated arguments of the method.